### PR TITLE
chore: remove indirect deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,6 @@ go 1.13
 require (
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
-	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
-	golang.org/x/sys v0.0.0-20190924092210-98129a5cf4a0 // indirect
-	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190916214212-f660b8655731
 	google.golang.org/grpc v1.23.1
 )


### PR DESCRIPTION
remove indirect dependencies because renovatebot is annoying