### PR TITLE
chore: set renovatebot timezone to PST

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,6 @@
       "packageNames": ["google.golang.org/genproto"],
       "schedule": "after 12pm on monday"
     }
-  ]
+  ],
+  "timezone": "America/Los_Angeles"
 }


### PR DESCRIPTION
This makes the `schedule` reference our team's local timezone