### PR TITLE
chore: codeowners change to actools-go

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/actools @googleapis/yoshi-go
+*     @googleapis/actools-go


### PR DESCRIPTION
This repo is only used by ACTools in `gapic-showcase` and doesn't need any new features. The traffic is just Go dependency updates. Limiting CODEOWNERS to `actools-go`.